### PR TITLE
Fetch turn server creds from Secrets Manager

### DIFF
--- a/containers/turn-server/Dockerfile
+++ b/containers/turn-server/Dockerfile
@@ -2,7 +2,7 @@ ARG alpine_ver=3.16
 FROM alpine:${alpine_ver}
 
 RUN apk update && \
-    apk add --no-cache  curl bind-tools  coturn
+    apk add --no-cache  curl bind-tools  coturn aws-cli
 
 COPY turnserver.conf /etc/turnserver.conf
 COPY entrypoint.sh /entrypoint.sh

--- a/containers/turn-server/entrypoint.sh
+++ b/containers/turn-server/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Determine external ip address
 if [ -z "$EXTERNAL_IP" ]; then
-    EXTERNAL_IP=$(curl -s icanhazip.com)
+    EXTERNAL_IP=$(curl -s https://checkip.amazonaws.com/)
 fi
 
 # Get internal ip address from eth0
@@ -10,4 +10,8 @@ if [ -z "$INTERNAL_IP" ]; then
     INTERNAL_IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
 fi
 
+USER=$(aws secretsmanager get-secret-value --secret-id pixel/ice/user --query "SecretString" --output text)
+PASSWORD=$(aws secretsmanager get-secret-value --secret-id pixel/ice/password --query "SecretString" --output text)
+
+sed -e "s/USERCREDS/${USER}:${PASSWORD}/" -i /etc/turnserver.conf
 turnserver --log-file=stdout --external-ip="$EXTERNAL_IP" --listening-ip="$INTERNAL_IP" 

--- a/containers/turn-server/turnserver.conf
+++ b/containers/turn-server/turnserver.conf
@@ -13,5 +13,5 @@ log-file=stdout
 
 verbose
 
-user=user:RifyF3akkEmCrFr4rx8K7Wq6xbiXt6da
+user=USERCREDS
 lt-cred-mech


### PR DESCRIPTION
Modified Dockerfile, entrypoint.sh and turnserver.conf

Container must run in pod which has IAM permissions for read access to the secrets.

ALso fixed the external IP curl call to comply with AWS security guidance.